### PR TITLE
Show "execute:" description when running executes commands

### DIFF
--- a/cmd/cbuild2cmake/commands/root_test.go
+++ b/cmd/cbuild2cmake/commands/root_test.go
@@ -274,6 +274,7 @@ set(OUTPUT
 add_custom_target(project.Release+ARMCM0-Sign_Artifact ALL DEPENDS ${OUTPUT})
 add_custom_command(OUTPUT ${OUTPUT} DEPENDS ${INPUT}
   COMMAND ${CMAKE_COMMAND} -DINPUT="${INPUT}" -DOUTPUT="${OUTPUT}" -P "${INPUT_0}"
+  COMMENT project.Release+ARMCM0-Sign_Artifact
 )`)
 		assert.Contains(content, `
 # Build dependencies

--- a/pkg/maker/buildcontent.go
+++ b/pkg/maker/buildcontent.go
@@ -782,7 +782,8 @@ func ExecutesCommands(executes []Executes) string {
 		customTarget := "\nadd_custom_target(" + item.Execute + " ALL"
 		runAlways := item.Always != nil
 		if runAlways {
-			customTarget += "\n  COMMAND " + QuoteArguments(item.Run) + "\n)"
+			customTarget += "\n  COMMAND " + QuoteArguments(item.Run)
+			customTarget += "\n  COMMENT " + item.Execute + "\n)"
 		} else {
 			customTarget += " DEPENDS ${OUTPUT})"
 		}
@@ -800,7 +801,8 @@ func ExecutesCommands(executes []Executes) string {
 		}
 		content += customTarget
 		if !runAlways {
-			customCommand += "\n  COMMAND " + QuoteArguments(item.Run) + "\n)"
+			customCommand += "\n  COMMAND " + QuoteArguments(item.Run)
+			customCommand += "\n  COMMENT " + item.Execute + "\n)"
 			content += customCommand
 		}
 	}


### PR DESCRIPTION
Currently, the command description when running the execute command during the build is just the command itself. This PR changes the CMake `COMMENT` for the custom target/command so that while the execute command is run the user-given description is shown instead of the raw command.

This makes the build output look a bit cleaner. The output isn't perfect since the description is present in the `cbuild-idx.yml` in a mangled form to be suitable for a CMake target name. For perfect user experience that should probably be a human-readable name including spaces.

## Example

```
  executes:
    - execute: Generating foobar source
      run: python $input(0)$ $input(1)$ -o $output(0)$
      input:
        - scripts/generate.py
        - src/foobar.in
      output:
        - src/foobar.c
```

## Current Output

```
[2/11] cd /path/to/project/tmp && python /path/to/project/scripts/generate.py /path/to/project/src/foobar.in -o /path/to/project/src/foobar.c
```

## New Output

```
[2/11] project+context-Generating_foobar_source
```

## Optimal Output

```
[2/11] project+context: Generating foobar source
```