### PR TITLE
Add bin and hex outputs to ExternalProject_Add BUILD_BYPRODUCTS

### DIFF
--- a/cmd/cbuild2cmake/commands/root_test.go
+++ b/cmd/cbuild2cmake/commands/root_test.go
@@ -124,10 +124,16 @@ set(DIRS
   "${CMAKE_CURRENT_SOURCE_DIR}/project.IAR+ARMCM0"
 )`)
 		assert.Contains(content, `
-set(OUTPUTS
+set(OUTPUTS_1
   "${SOLUTION_ROOT}/out/project/ARMCM0/AC6/project.axf"
+)
+set(OUTPUTS_2
   "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG/project.elf"
+)
+set(OUTPUTS_3
   "${SOLUTION_ROOT}/out/project/ARMCM0/GCC/project.elf"
+)
+set(OUTPUTS_4
   "${SOLUTION_ROOT}/out/project/ARMCM0/IAR/project.out"
 )`)
 
@@ -159,7 +165,7 @@ set(DIRS
   "${CMAKE_CURRENT_SOURCE_DIR}/project.Release+ARMCM0"
 )`)
 		assert.Contains(content, `
-set(OUTPUTS
+set(OUTPUTS_1
   "${SOLUTION_ROOT}/out/project/ARMCM0/Release/project.axf"
 )`)
 	})


### PR DESCRIPTION
This PR allows executes commands to depend on .bin and .hex files from projects.

The previous implementation assumed every context only has one output file, and had one global `set(OUTPUTS ...)` array with a single entry per context. This PR replaces this array with per-context `set(OUTPUTS_1 ...)`, `set(OUTPUTS_2 ...)`, ... arrays, and gets the corresponding array with `${OUTPUTS_${N}}` for the `ExternalProject_Add` call.

The resulting change to the generated CMake is thus fairly minimal, while still allowing executes to use `.bin` and `.hex` files from projects.

Fixes #126