### PR TITLE
Restrict Coverage upload from forked repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,7 @@ jobs:
           make coverage-check
 
       - name: Publish coverage report to Code Climate
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
         uses: paambaati/codeclimate-action@b74bb25d2074a4bc16bd06fffc1b299c07b1f886 # v6.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
Secrets are not accessible for contributions from forked repositories, causing the coverage upload step to fail. This is a temporary solution to prevent coverage uploads from forked repositories.