### PR TITLE
[cbuild2cmake] Add CMake `make_directory` command into database target

### DIFF
--- a/pkg/maker/contextlists.go
+++ b/pkg/maker/contextlists.go
@@ -124,7 +124,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES ` + strings.Join(cbuild.Languages, " ") + `)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")` + systemIncludes + `
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)` + systemIncludes + `
 
 # Setup context
 ` + cmakeTargetType + `(${CONTEXT})

--- a/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C ASM)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C ASM)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C ASM)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C ASM)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
@@ -20,7 +20,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES CXX C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
@@ -21,7 +21,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES CXX C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
@@ -20,7 +20,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES CXX C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
@@ -21,7 +21,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES CXX C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES ASM C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES ASM C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES ASM C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C CXX)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C CXX)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C CXX)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C CXX)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -22,7 +22,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -22,7 +22,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -22,7 +22,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -22,7 +22,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -18,7 +18,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context

--- a/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -19,7 +19,10 @@ include("toolchain.cmake")
 project(${CONTEXT} LANGUAGES C)
 
 # Compilation database
-add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}")
+add_custom_target(database
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OUT_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" "${OUT_DIR}"
+)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 
 # Setup context


### PR DESCRIPTION
Add CMake [make_directory](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-make_directory) before calling [copy_if_different](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-copy_if_different) because copy_if_different requires the directory must exist.

Address https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/158