### PR TITLE
[cbuild2cmake] Increase CMake minimum version

### DIFF
--- a/pkg/maker/contextlists.go
+++ b/pkg/maker/contextlists.go
@@ -108,7 +108,7 @@ func (m *Maker) CreateContextCMakeLists(index int) error {
 	}
 
 	// Create CMakeLists content
-	content := `cmake_minimum_required(VERSION 3.22)
+	content := `cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT ` + cbuild.BuildDescType.Context + `)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM55)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM55)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM55)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM55)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})

--- a/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.27)
 
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})


### PR DESCRIPTION
Increase CMake minimum version due to CMake generator expressions needed for handling `del-path` and `undefine` were first introduced in CMake 3.27, see `$<LIST:REMOVE_ITEM,...>` and `$<LIST:FILTER,...>` in
https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#list-transformations