### PR TITLE
[cbuild2cmake] make contextlists buildable independent of superlists

### DIFF
--- a/pkg/maker/contextlists.go
+++ b/pkg/maker/contextlists.go
@@ -110,6 +110,9 @@ func (m *Maker) CreateContextCMakeLists(index int) error {
 	// Create CMakeLists content
 	content := `cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT ` + cbuild.BuildDescType.Context + `)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "` + outDir + `")

--- a/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")

--- a/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")

--- a/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")

--- a/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")

--- a/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")

--- a/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")

--- a/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")

--- a/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")

--- a/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM55)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/AC6")

--- a/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM55)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/CLANG")

--- a/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM55)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/GCC")

--- a/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM55)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/IAR")

--- a/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")

--- a/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")

--- a/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")

--- a/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")

--- a/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")

--- a/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")

--- a/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")

--- a/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")

--- a/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")

--- a/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")

--- a/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")

--- a/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")

--- a/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")

--- a/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")

--- a/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")

--- a/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")

--- a/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.AC6+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")

--- a/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.CLANG+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")

--- a/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.GCC+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")

--- a/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.27)
 
+# Roots
+include("../roots.cmake")
+
 set(CONTEXT project.IAR+ARMCM0)
 set(TARGET ${CONTEXT})
 set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")


### PR DESCRIPTION
Previously the context CMakeLists depended on variables from superlists CMakeLists (`CMSIS_PACK_ROOT` for pack root, `CMSIS_COMPILER_ROOT` for compiler root, and `SOLUTION_ROOT` for solution root), which made it impossible to load the context CMakeLists into an IDE like CLion without manually setting these variables.

This PR makes the context CMakeLists include the root variables so they can be used independently, but have those variables be overridable by the superlists so that they have consistent values when used via `cbuild` and the superlists. The root variables are also moved out into a separate `roots.cmake` to avoid duplication.

This is necessary since CLion currently does not understand `ExternalProject_Add`, which means loading the superlists into CLion is currently almost useless, since CLion won't be able to correctly read out compile options for the different projects. With this PR, the generated context CMakeLists can be used in CLion directly.

There is an [open issue](https://youtrack.jetbrains.com/issue/CPP-252/Support-ExternalProjectAdd) for CLion to support superbuild-style projects with `ExternalProject_Add`, but that issue was opened over 10 years ago and doesn't see much progress. If it were forseeable that CLion grew support for superbuilds in the near future I would not opt for this change, but seeing as the progress on this is slow this small change to `cbuild2cmake` seems to be to be the least bad option if users should be allowed to use an IDE of their choice.