### PR TITLE
[cbuild2cmake] Build compilation database by default and add database target to superlists

### DIFF
--- a/pkg/maker/superlists.go
+++ b/pkg/maker/superlists.go
@@ -116,7 +116,6 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
   # Database generation step
   ExternalProject_Add_Step(${CONTEXT} database
     COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database
-    EXCLUDE_FROM_MAIN TRUE
     ALWAYS            TRUE
     DEPENDEES         configure
   )

--- a/pkg/maker/superlists.go
+++ b/pkg/maker/superlists.go
@@ -87,6 +87,9 @@ set(ARGS
   "-DCMSIS_COMPILER_ROOT=${CMSIS_COMPILER_ROOT}"
 )
 
+# Compilation database
+add_custom_target(database)
+
 # Iterate over contexts
 foreach(INDEX RANGE ${CONTEXTS_LENGTH})
 
@@ -120,6 +123,7 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
     DEPENDEES         configure
   )
   ExternalProject_Add_StepTargets(${CONTEXT} database)
+  add_dependencies(database ${CONTEXT}-database)
 
 endforeach()` + m.ExecutesCommands(m.CbuildIndex.BuildIdx.Executes) + m.BuildDependencies() + `
 `

--- a/test/data/solutions/blanks/ref/CMakeLists.txt
+++ b/test/data/solutions/blanks/ref/CMakeLists.txt
@@ -57,7 +57,6 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
   # Database generation step
   ExternalProject_Add_Step(${CONTEXT} database
     COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database
-    EXCLUDE_FROM_MAIN TRUE
     ALWAYS            TRUE
     DEPENDEES         configure
   )

--- a/test/data/solutions/blanks/ref/CMakeLists.txt
+++ b/test/data/solutions/blanks/ref/CMakeLists.txt
@@ -28,6 +28,9 @@ set(ARGS
   "-DCMSIS_COMPILER_ROOT=${CMSIS_COMPILER_ROOT}"
 )
 
+# Compilation database
+add_custom_target(database)
+
 # Iterate over contexts
 foreach(INDEX RANGE ${CONTEXTS_LENGTH})
 
@@ -61,5 +64,6 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
     DEPENDEES         configure
   )
   ExternalProject_Add_StepTargets(${CONTEXT} database)
+  add_dependencies(database ${CONTEXT}-database)
 
 endforeach()

--- a/test/data/solutions/pre-include-oot/ref/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/CMakeLists.txt
@@ -43,6 +43,9 @@ set(ARGS
   "-DCMSIS_COMPILER_ROOT=${CMSIS_COMPILER_ROOT}"
 )
 
+# Compilation database
+add_custom_target(database)
+
 # Iterate over contexts
 foreach(INDEX RANGE ${CONTEXTS_LENGTH})
 
@@ -76,5 +79,6 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
     DEPENDEES         configure
   )
   ExternalProject_Add_StepTargets(${CONTEXT} database)
+  add_dependencies(database ${CONTEXT}-database)
 
 endforeach()

--- a/test/data/solutions/pre-include-oot/ref/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/CMakeLists.txt
@@ -72,7 +72,6 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
   # Database generation step
   ExternalProject_Add_Step(${CONTEXT} database
     COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database
-    EXCLUDE_FROM_MAIN TRUE
     ALWAYS            TRUE
     DEPENDEES         configure
   )


### PR DESCRIPTION
This PR makes the database step run by default, since it is very cheap and in almost all cases the compilation database is needed anyway. This also ensures the compilation database in the `out/` folder is up-to-date without needing to run `cbuild setup` after every project change.

This PR also adds a `database` target to the superlists CMake, which automatically triggers database generation for all contexts. This makes it quite convenient to generate all compilation databases without needing to spell out the individual context targets.

I'm not sure if this is what you have in mind for the compilation database generation flow, but it would greatly improve our workflow, since separately running `cbuild setup` is (a) sometimes slow, and (b) `cbuild setup` doesn't work properly for some of our projects since we have solutions where we build multiple projects with different target-types together, which `cbuild setup` doesn't support ("invalid combination of contexts specified in SOLUTION.cbuild-set.yml").