### PR TITLE
[cbuild2cmake] Fix executes with always tag not creating CMake outputs

### DIFF
--- a/pkg/maker/buildcontent.go
+++ b/pkg/maker/buildcontent.go
@@ -834,6 +834,9 @@ func (m *Maker) ExecutesCommands(executes []Executes) string {
 		runAlways := item.Always != nil
 		if runAlways {
 			customTarget += "\n  COMMAND " + QuoteArguments(item.Run)
+			if len(item.Output) > 0 {
+				customTarget += "\n  BYPRODUCTS ${OUTPUT}"
+			}
 			customTarget += "\n  COMMENT " + item.Execute + "\n)"
 		} else {
 			customTarget += " DEPENDS ${OUTPUT})"


### PR DESCRIPTION
This PR changes the generated `add_custom_target()` statements to correctly define output files of executes statements with `always:` tag so that dependent executes statements have correct CMake dependencies. Otherwise the build breaks due to missing rules to make the dependencies.

Fixes #208.