### PR TITLE
[cbuild2cmake] Reduce default verbosity of `database` step

### DIFF
--- a/pkg/maker/superlists.go
+++ b/pkg/maker/superlists.go
@@ -46,12 +46,13 @@ func (m *Maker) CreateSuperCMakeLists() error {
 	solutionRoot, _ := filepath.EvalSymlinks(m.SolutionRoot)
 	solutionRoot = filepath.ToSlash(solutionRoot)
 
-	var verbosity, logConfigure string
+	var verbosity, logConfigure, stepLog string
 	if m.Options.Debug || m.Options.Verbose {
 		verbosity = " --verbose"
 	} else {
 		logConfigure = "\n    LOG_CONFIGURE         ON"
 		logConfigure += "\n    LOG_OUTPUT_ON_FAILURE ON"
+		stepLog = "\n    LOG               TRUE"
 	}
 
 	// Create roots.cmake
@@ -123,8 +124,9 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
 
   # Database generation step
   ExternalProject_Add_Step(${CONTEXT} database
-    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database
-    ALWAYS            TRUE
+    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database` + verbosity + `
+    ALWAYS            TRUE` + stepLog + `
+    USES_TERMINAL     ON
     DEPENDEES         configure
   )
   ExternalProject_Add_StepTargets(${CONTEXT} database)

--- a/test/data/solutions/blanks/ref/CMakeLists.txt
+++ b/test/data/solutions/blanks/ref/CMakeLists.txt
@@ -64,8 +64,9 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
 
   # Database generation step
   ExternalProject_Add_Step(${CONTEXT} database
-    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database
+    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database --verbose
     ALWAYS            TRUE
+    USES_TERMINAL     ON
     DEPENDEES         configure
   )
   ExternalProject_Add_StepTargets(${CONTEXT} database)

--- a/test/data/solutions/executes/ref/CMakeLists.txt
+++ b/test/data/solutions/executes/ref/CMakeLists.txt
@@ -64,8 +64,9 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
 
   # Database generation step
   ExternalProject_Add_Step(${CONTEXT} database
-    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database
+    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database --verbose
     ALWAYS            TRUE
+    USES_TERMINAL     ON
     DEPENDEES         configure
   )
   ExternalProject_Add_StepTargets(${CONTEXT} database)

--- a/test/data/solutions/pre-include-oot/ref/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/CMakeLists.txt
@@ -79,8 +79,9 @@ foreach(INDEX RANGE ${CONTEXTS_LENGTH})
 
   # Database generation step
   ExternalProject_Add_Step(${CONTEXT} database
-    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database
+    COMMAND           ${CMAKE_COMMAND} --build <BINARY_DIR> --target database --verbose
     ALWAYS            TRUE
+    USES_TERMINAL     ON
     DEPENDEES         configure
   )
   ExternalProject_Add_StepTargets(${CONTEXT} database)


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->

- Complementary to https://github.com/Open-CMSIS-Pack/cbuild2cmake/pull/196

## Changes
<!-- List the changes this PR introduces -->

- By default do not print `database` step message. Verbose messages are enabled in debug mode.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by unit tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [x] 📖 All documentation updates are complete.
- [x] 🧠 This change does not change third-party dependencies
