### PR TITLE
[cbuild2cmake] Fix linker `lto` flag

### DIFF
--- a/pkg/maker/buildcontent.go
+++ b/pkg/maker/buildcontent.go
@@ -850,7 +850,7 @@ func (c *Cbuild) LinkerOptions() (linkerVars string, linkerOptions string) {
 	if len(c.BuildDescType.Processor.Trustzone) > 0 {
 		linkerOptions += "\n  " + AddShellPrefix("${LD_SECURE}")
 	}
-	if c.LinkerLto {
+	if c.LinkerLto || c.BuildDescType.Lto {
 		linkerOptions += "\n  " + AddShellPrefix("${LD_LTO}")
 	}
 	options := c.BuildDescType.Misc.Link

--- a/test/data/solutions/build-cpp/project/project.AC6+ARMCM55.cbuild.yml
+++ b/test/data/solutions/build-cpp/project/project.AC6+ARMCM55.cbuild.yml
@@ -6,6 +6,7 @@ build:
   compiler: AC6
   device: ARMCM55
   device-pack: ARM::Cortex_DFP@1.0.0
+  link-time-optimize: true
   processor:
     dsp: on
     fpu: dp

--- a/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
@@ -57,6 +57,7 @@ target_compile_options(${CONTEXT} PUBLIC
   $<$<COMPILE_LANGUAGE:C>:
     "SHELL:${CC_CPU}"
     "SHELL:${CC_FLAGS}"
+    "SHELL:${CC_LTO}"
     "SHELL:-std=gnu11"
     "SHELL:-Wno-macro-redefined"
     "SHELL:-Wno-pragma-pack"
@@ -66,6 +67,7 @@ target_compile_options(${CONTEXT} PUBLIC
   $<$<COMPILE_LANGUAGE:CXX>:
     "SHELL:${CXX_CPU}"
     "SHELL:${CXX_FLAGS}"
+    "SHELL:${CXX_LTO}"
     "SHELL:-Wno-macro-redefined"
     "SHELL:-Wno-pragma-pack"
     "SHELL:-Wno-parentheses-equality"
@@ -87,6 +89,7 @@ target_link_libraries(${CONTEXT} PUBLIC
 target_link_options(${CONTEXT} PUBLIC
   "SHELL:${LD_CPU}"
   "SHELL:${_LS}\"${LD_SCRIPT_PP}\""
+  "SHELL:${LD_LTO}"
   "SHELL:--entry=Reset_Handler"
   "SHELL:--map"
   "SHELL:--info summarysizes"

--- a/test/data/solutions/build-cpp/solution.csolution.yml
+++ b/test/data/solutions/build-cpp/solution.csolution.yml
@@ -13,6 +13,7 @@ solution:
   build-types:
     - type: AC6
       compiler: AC6
+      link-time-optimize:
 
     - type: GCC
       compiler: GCC


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- Reported by @jkrech: The linker `lto` flag is not set if `link-time-optimize` is set at global level but not at group or component level.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
