### PR TITLE
[cbuild2cmake] Add `USES_TERMINAL` for `executes` custom target/command

### DIFF
--- a/pkg/maker/buildcontent.go
+++ b/pkg/maker/buildcontent.go
@@ -926,7 +926,7 @@ func (m *Maker) ExecutesCommands(executes []Executes) string {
 			if len(item.Output) > 0 {
 				customTarget += "\n  BYPRODUCTS ${OUTPUT}"
 			}
-			customTarget += "\n)"
+			customTarget += "\n  USES_TERMINAL\n)"
 		} else {
 			customTarget += " DEPENDS ${OUTPUT})"
 		}
@@ -951,7 +951,7 @@ func (m *Maker) ExecutesCommands(executes []Executes) string {
 			if !executeCommandNameAdded {
 				customCommand += "\n  COMMAND ${CMAKE_COMMAND} -E echo \"Executing: " + item.Execute + "\""
 			}
-			customCommand += "\n  COMMAND " + QuoteArguments(item.Run) + "\n)"
+			customCommand += "\n  COMMAND " + QuoteArguments(item.Run) + "\n  USES_TERMINAL\n)"
 			content += customCommand
 		}
 	}

--- a/test/data/solutions/executes/ref/CMakeLists.txt
+++ b/test/data/solutions/executes/ref/CMakeLists.txt
@@ -88,6 +88,7 @@ add_custom_target(Archive_Artifacts ALL DEPENDS ${OUTPUT})
 add_custom_command(OUTPUT ${OUTPUT} DEPENDS ${INPUT}
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: Archive_Artifacts"
   COMMAND ${CMAKE_COMMAND} -DINPUT="${INPUT}" -DOUTPUT="${OUTPUT}" -P "${INPUT_0}"
+  USES_TERMINAL
 )
 
 # Execute: Generate_Project_Sources
@@ -107,6 +108,7 @@ add_custom_target(Generate_Project_Sources ALL DEPENDS ${OUTPUT})
 add_custom_command(OUTPUT ${OUTPUT} DEPENDS ${INPUT}
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: Generate_Project_Sources"
   COMMAND ${CMAKE_COMMAND} -DINPUT_1="${INPUT_1}" -DOUTPUT_0="${OUTPUT_0}" -DOUTPUT_1="${OUTPUT_1}" -P "${INPUT_0}"
+  USES_TERMINAL
 )
 
 # Execute: Run_After_Archiving
@@ -121,18 +123,21 @@ add_custom_command(OUTPUT ${OUTPUT} DEPENDS ${INPUT}
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: Run_After_Archiving"
   COMMAND ${CMAKE_COMMAND} -E touch "Run_After_Archiving.stamp"
   COMMAND ${CMAKE_COMMAND} -E echo "Archive has been updated"
+  USES_TERMINAL
 )
 
 # Execute: Run_Always1
 add_custom_target(Run_Always1 ALL
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: Run_Always1"
   COMMAND ${CMAKE_COMMAND} -E echo "Execute Run Always1"
+  USES_TERMINAL
 )
 
 # Execute: Run_Always2
 add_custom_target(Run_Always2 ALL
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: Run_Always2"
   COMMAND ${CMAKE_COMMAND} -E echo "Execute Run Always2"
+  USES_TERMINAL
 )
 
 # Execute: project.Release+ARMCM0-Sign_Artifact
@@ -148,6 +153,7 @@ add_custom_target(project.Release+ARMCM0-Sign_Artifact ALL DEPENDS ${OUTPUT})
 add_custom_command(OUTPUT ${OUTPUT} DEPENDS ${INPUT}
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: project.Release+ARMCM0-Sign_Artifact"
   COMMAND ${CMAKE_COMMAND} -DINPUT="${INPUT}" -DOUTPUT="${OUTPUT}" -P "${INPUT_0}"
+  USES_TERMINAL
 )
 
 # Build dependencies

--- a/test/data/solutions/image-only/ref/CMakeLists.txt
+++ b/test/data/solutions/image-only/ref/CMakeLists.txt
@@ -18,6 +18,7 @@ add_custom_target(Convert_Image1 ALL DEPENDS ${OUTPUT})
 add_custom_command(OUTPUT ${OUTPUT} DEPENDS ${INPUT}
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: Convert_Image1"
   COMMAND ${CMAKE_COMMAND} -E echo "Simulate image conversion 1 > 2" && ${CMAKE_COMMAND} -E copy "${INPUT_0}" "${OUTPUT_0}"
+  USES_TERMINAL
 )
 
 # Execute: Convert_Image2
@@ -33,6 +34,7 @@ add_custom_target(Convert_Image2 ALL DEPENDS ${OUTPUT})
 add_custom_command(OUTPUT ${OUTPUT} DEPENDS ${INPUT}
   COMMAND ${CMAKE_COMMAND} -E echo "Executing: Convert_Image2"
   COMMAND ${CMAKE_COMMAND} -E echo "Simulate image conversion 2 > 3" && ${CMAKE_COMMAND} -E copy "${INPUT_0}" "${OUTPUT_0}"
+  USES_TERMINAL
 )
 
 # Build dependencies


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/2142#issuecomment-3052957594

## Changes
<!-- List the changes this PR introduces -->
- Add `USES_TERMINAL` for executes custom target/command
- Update test cases

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
