### PR TITLE
[cbuild2cmake] Improve zephyr module generation

### DIFF
--- a/pkg/maker/zephyr.go
+++ b/pkg/maker/zephyr.go
@@ -166,8 +166,6 @@ func (m *Maker) GenerateModuleKconfig() error {
 	// Iterate over zephyr layers
 	for _, zephyrLayer := range m.ZephyrMaker.Layers {
 		menuConfigName := "CMSIS_" + strings.ToUpper(ReplaceSpecialChars(zephyrLayer.Clayer.Name))
-		source, _ := filepath.Rel(m.SolutionRoot, zephyrLayer.Clayer.File)
-		source = filepath.ToSlash(source)
 		cpp := ""
 		if slices.Contains(m.ZephyrMaker.Cbuild.Languages, "CXX") {
 			cpp = "\n    depends on CPP && STD_CPP17"
@@ -177,7 +175,7 @@ func (m *Maker) GenerateModuleKconfig() error {
     default y
     help
         ` + zephyrLayer.Clayer.Layer.Description + `
-        Source: ` + source + "\n\n"
+        Source: ` + filepath.Base(zephyrLayer.Clayer.File) + "\n\n"
 
 		// Iterate over components
 		content += "if " + menuConfigName + "\n\n"
@@ -229,7 +227,9 @@ func (m *Maker) GenerateModuleCMakeSources() error {
 		fallback := ""
 		pdscs := []string{}
 		// Iterate over used packs and set pack paths
-		for packId, packPath := range m.ZephyrMaker.PackPaths {
+		for _, pack := range sortedmap.AsSortedMap(m.ZephyrMaker.PackPaths) {
+			packId := pack.Key
+			packPath := pack.Value
 			packName := strings.ToUpper(ReplaceSpecialChars(strings.SplitN(packId, "@", 2)[0]))
 			content += "cmake_path(SET " + packName + " NORMALIZE \"" + packPath + "\")\n"
 			vendor, name, version := utils.ExtractPackIdParts(packId)

--- a/pkg/maker/zephyr_test.go
+++ b/pkg/maker/zephyr_test.go
@@ -72,7 +72,7 @@ func TestZephyr(t *testing.T) {
 		text := string(content)
 		assert.Contains(text, "menuconfig CMSIS_LAYER_MAIN")
 		assert.Contains(text, "depends on CPP && STD_CPP17")
-		assert.Contains(text, "Source: layers/layer-main.clayer.yml")
+		assert.Contains(text, "Source: layer-main.clayer.yml")
 		assert.Contains(text, "config CMSIS_LAYER_MAIN_VENDOR_PACK_COMP")
 		assert.Contains(text, "Component: Vendor::Pack:Comp@1.0.0")
 	})
@@ -113,7 +113,8 @@ func TestZephyr(t *testing.T) {
 		cbuild.BuildDescType.Define = []interface{}{"DEF_SCALAR", map[string]interface{}{"DEF_KEY": "VALUE"}}
 		m.ZephyrMaker.Cbuild = &cbuild
 		m.ZephyrMaker.PackPaths = map[string]string{
-			"Vendor::Pack@1.0.0": "${CMAKE_CURRENT_LIST_DIR}/packs/vendor/pack",
+			"Another::Pack@2.0.0": "${CMAKE_CURRENT_LIST_DIR}/packs/another/pack",
+			"Vendor::Pack@1.0.0":  "${CMAKE_CURRENT_LIST_DIR}/packs/vendor/pack",
 		}
 		m.ZephyrMaker.CompileOptions = map[string][]string{
 			"C":   {"-O2"},
@@ -150,6 +151,7 @@ func TestZephyr(t *testing.T) {
 		assert.NoError(err)
 		text := string(content)
 		assert.Contains(text, "set(CMSIS_PACK_ROOT $ENV{CMSIS_PACK_ROOT})")
+		assert.Less(strings.Index(text, "cmake_path(SET ANOTHER_PACK NORMALIZE"), strings.Index(text, "cmake_path(SET VENDOR_PACK NORMALIZE"))
 		assert.Contains(text, "cmake_path(SET VENDOR_PACK NORMALIZE \"${CMAKE_CURRENT_LIST_DIR}/packs/vendor/pack\")")
 		assert.Contains(text, "if(NOT EXISTS \"${VENDOR_PACK}/Vendor.Pack.pdsc\")")
 		assert.Contains(text, "cmake_path(SET VENDOR_PACK NORMALIZE \"${CMSIS_PACK_ROOT}/Vendor/Pack/1.0.0\")")
@@ -175,6 +177,12 @@ func TestZephyr(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
 		root := filepath.ToSlash(t.TempDir())
+		wd, err := os.Getwd()
+		require.NoError(err)
+		require.NoError(os.Chdir(root))
+		t.Cleanup(func() {
+			_ = os.Chdir(wd)
+		})
 		baseDir := path.Join(root, "build")
 		require.NoError(os.MkdirAll(baseDir, 0o755))
 
@@ -231,7 +239,7 @@ func TestZephyr(t *testing.T) {
 		}
 		m.Cbuilds = []maker.Cbuild{cbuild}
 
-		err := m.GenerateZephyrModules()
+		err = m.GenerateZephyrModules()
 		assert.NoError(err)
 		assert.True(m.ZephyrMaker.RteComponents)
 		assert.True(m.ZephyrMaker.PreIncludeGlobal)


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/2429

## Changes
<!-- List the changes this PR introduces -->
- Kconfig source line simplified
- Deterministic pack ordering, making pack-dependent output ordering stable across runs
- Update test cases

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
