### PR TITLE
Generate language-specific compile macro files

### DIFF
--- a/pkg/maker/contextlists.go
+++ b/pkg/maker/contextlists.go
@@ -70,6 +70,7 @@ func (m *Maker) CreateContextCMakeLists(index int) error {
 			systemIncludes += "\nset(CMAKE_" + language + "_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_" + language + "_IMPLICIT_INCLUDE_DIRECTORIES})"
 		}
 	}
+	preprocessorOptions, compileMacros, compileMacroDependencies, compileMacroCommands := cbuild.PreprocessorOptions()
 
 	// Constructed files: collect headers and global pre-includes
 	constructedFiles := cbuild.ClassifyFiles(cbuild.BuildDescType.ConstructedFiles)
@@ -124,8 +125,7 @@ set(DPACK_DIR "` + cbuild.AddRootPrefix(cbuild.ContextRoot, cbuild.GetDpackDir()
 set(OUT_DIR "` + outDir + `")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
-set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)` + outputByProducts + linkerVars + `
+set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)` + compileMacros + outputByProducts + linkerVars + `
 
 # Processor Options` + cbuild.ProcessorOptions() + `
 
@@ -139,15 +139,15 @@ project(${CONTEXT} LANGUAGES ` + strings.Join(cbuild.Languages, " ") + `)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options` + preprocessorOptions + `
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS}` + compileMacroDependencies + `)
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
-)` + systemIncludes + `
+` + compileMacroCommands + systemIncludes + `
 
 # Setup context
 ` + cmakeTargetType + `(${CONTEXT})
@@ -174,6 +174,38 @@ include("components.cmake")
 		return err
 	}
 	return err
+}
+
+func (c *Cbuild) PreprocessorOptions() (options string, macros string, dependencies string, commands string) {
+	var commandLines string
+	for _, language := range c.Languages {
+		var languageOption string
+		var miscOptions []string
+		switch language {
+		case "C":
+			languageOption = "-xc"
+			miscOptions = append(c.BuildDescType.Misc.C, c.BuildDescType.Misc.CCPP...)
+		case "CXX":
+			languageOption = "-xc++"
+			miscOptions = append(c.BuildDescType.Misc.CPP, c.BuildDescType.Misc.CCPP...)
+		default:
+			continue
+		}
+
+		options += "\nset(CPP_OPTIONS_" + language + " \"" + languageOption + "\""
+		for _, option := range miscOptions {
+			option = strings.ReplaceAll(c.AdjustRelativePath(option), "\"", "\\\"")
+			options += " \"" + option + "\""
+		}
+		options += ")"
+		macros += "\nset(COMPILE_MACROS_" + language + " ${OUT_DIR}/compile_macros_" + strings.ToLower(language) + ".h)"
+		dependencies += " ${COMPILE_MACROS_" + language + "}"
+		commandLines += "\n  COMMAND ${CPP} ${CPP_OPTIONS_" + language + "} ${CPP_DUMP_MACROS} \"${COMPILE_MACROS_" + language + "}\""
+	}
+	if len(commandLines) > 0 {
+		commands = "add_custom_command(OUTPUT" + dependencies + commandLines + "\n)"
+	}
+	return options, macros, dependencies, commands
 }
 
 func (m *Maker) CMakeCreateToolchain(index int, contextDir string, inc bool) error {

--- a/pkg/maker/contextlists.go
+++ b/pkg/maker/contextlists.go
@@ -191,8 +191,18 @@ func (c *Cbuild) PreprocessorOptions() (options string, macros string, dependenc
 		default:
 			continue
 		}
+		if c.Toolchain == "IAR" {
+			if language == "CXX" {
+				languageOption = "--c++"
+			} else {
+				languageOption = ""
+			}
+		}
 
-		options += "\nset(CPP_OPTIONS_" + language + " \"" + languageOption + "\""
+		options += "\nset(CPP_OPTIONS_" + language
+		if len(languageOption) > 0 {
+			options += " \"" + languageOption + "\""
+		}
 		for _, option := range miscOptions {
 			option = strings.ReplaceAll(c.AdjustRelativePath(option), "\"", "\\\"")
 			options += " \"" + option + "\""

--- a/pkg/maker/contextlists.go
+++ b/pkg/maker/contextlists.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/Open-CMSIS-Pack/cbuild2cmake/pkg/utils"
 	"golang.org/x/exp/maps"
@@ -204,8 +205,11 @@ func (c *Cbuild) PreprocessorOptions() (options string, macros string, dependenc
 			options += " \"" + languageOption + "\""
 		}
 		for _, option := range miscOptions {
-			option = strings.ReplaceAll(c.AdjustRelativePath(option), "\"", "\\\"")
-			options += " \"" + option + "\""
+			option = c.AdjustRelativePath(option)
+			for _, argument := range splitPreprocessorOption(option) {
+				argument = strings.ReplaceAll(argument, "\"", "\\\"")
+				options += " \"" + argument + "\""
+			}
 		}
 		options += ")"
 		macros += "\nset(COMPILE_MACROS_" + language + " ${OUT_DIR}/compile_macros_" + strings.ToLower(language) + ".h)"
@@ -216,6 +220,29 @@ func (c *Cbuild) PreprocessorOptions() (options string, macros string, dependenc
 		commands = "add_custom_command(OUTPUT" + dependencies + commandLines + "\n)"
 	}
 	return options, macros, dependencies, commands
+}
+
+func splitPreprocessorOption(option string) []string {
+	var arguments []string
+	var argument strings.Builder
+	inQuotes := false
+	for _, character := range option {
+		if character == '"' {
+			inQuotes = !inQuotes
+		}
+		if unicode.IsSpace(character) && !inQuotes {
+			if argument.Len() > 0 {
+				arguments = append(arguments, argument.String())
+				argument.Reset()
+			}
+			continue
+		}
+		argument.WriteRune(character)
+	}
+	if argument.Len() > 0 {
+		arguments = append(arguments, argument.String())
+	}
+	return arguments
 }
 
 func (m *Maker) CMakeCreateToolchain(index int, contextDir string, inc bool) error {

--- a/pkg/maker/contextlists_test.go
+++ b/pkg/maker/contextlists_test.go
@@ -44,4 +44,19 @@ func TestContextLists(t *testing.T) {
 		assert.Equal("add_custom_command(OUTPUT ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX}\n  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} \"${COMPILE_MACROS_C}\"\n  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} \"${COMPILE_MACROS_CXX}\"\n)", commands)
 		assert.NotContains(options+macros+dependencies+commands, "ASM")
 	})
+
+	t.Run("test IAR preprocessor options", func(t *testing.T) {
+		var cbuild maker.Cbuild
+		cbuild.Toolchain = "IAR"
+		cbuild.Languages = []string{"C", "CXX"}
+		cbuild.BuildDescType.Misc = maker.Misc{
+			C:   []string{"--c-option"},
+			CPP: []string{"--cxx-option"},
+		}
+
+		options, _, _, _ := cbuild.PreprocessorOptions()
+		assert.Contains(options, "set(CPP_OPTIONS_C \"--c-option\")")
+		assert.Contains(options, "set(CPP_OPTIONS_CXX \"--c++\" \"--cxx-option\")")
+		assert.NotContains(options, "-xc")
+	})
 }

--- a/pkg/maker/contextlists_test.go
+++ b/pkg/maker/contextlists_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Arm Limited. All rights reserved.
+ * Copyright (c) 2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,5 +25,23 @@ func TestContextLists(t *testing.T) {
 			err = m.CreateContextCMakeLists(index)
 			assert.Nil(err)
 		}
+	})
+
+	t.Run("test preprocessor options", func(t *testing.T) {
+		var cbuild maker.Cbuild
+		cbuild.Languages = []string{"ASM", "C", "CXX"}
+		cbuild.BuildDescType.Misc = maker.Misc{
+			C:    []string{"-c-option"},
+			CPP:  []string{"-cxx-option"},
+			CCPP: []string{"-common-option"},
+		}
+
+		options, macros, dependencies, commands := cbuild.PreprocessorOptions()
+		assert.Contains(options, "set(CPP_OPTIONS_C \"-xc\" \"-c-option\" \"-common-option\")")
+		assert.Contains(options, "set(CPP_OPTIONS_CXX \"-xc++\" \"-cxx-option\" \"-common-option\")")
+		assert.Equal("\nset(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)\nset(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)", macros)
+		assert.Equal(" ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX}", dependencies)
+		assert.Equal("add_custom_command(OUTPUT ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX}\n  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} \"${COMPILE_MACROS_C}\"\n  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} \"${COMPILE_MACROS_CXX}\"\n)", commands)
+		assert.NotContains(options+macros+dependencies+commands, "ASM")
 	})
 }

--- a/pkg/maker/contextlists_test.go
+++ b/pkg/maker/contextlists_test.go
@@ -45,6 +45,17 @@ func TestContextLists(t *testing.T) {
 		assert.NotContains(options+macros+dependencies+commands, "ASM")
 	})
 
+	t.Run("test preprocessor options with spaces", func(t *testing.T) {
+		var cbuild maker.Cbuild
+		cbuild.Languages = []string{"C"}
+		cbuild.BuildDescType.Misc = maker.Misc{
+			C: []string{`-DTEST=1 -include "path with spaces/header.h" -Wall`},
+		}
+
+		options, _, _, _ := cbuild.PreprocessorOptions()
+		assert.Contains(options, `set(CPP_OPTIONS_C "-xc" "-DTEST=1" "-include" "\"path with spaces/header.h\"" "-Wall")`)
+	})
+
 	t.Run("test IAR preprocessor options", func(t *testing.T) {
 		var cbuild maker.Cbuild
 		cbuild.Toolchain = "IAR"

--- a/test/data/solutions/abstractions/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/abstractions/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/blanks/ref/project X.AC6 X+ARMCM0 X/CMakeLists.txt
+++ b/test/data/solutions/blanks/ref/project X.AC6 X+ARMCM0 X/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project X/ARMCM0 X/AC6 X")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C ASM)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C ASM)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C ASM)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C ASM)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C ASM)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-asm/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C ASM)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/build-c/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.AC6+ARMCM55/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM55/ARMCM55_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -32,14 +33,19 @@ project(${CONTEXT} LANGUAGES CXX C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_CXX "-xc++" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.CLANG+ARMCM55/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM55/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM55/regions_ARMCM55.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -33,14 +34,19 @@ project(${CONTEXT} LANGUAGES CXX C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_CXX "-xc++" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.GCC+ARMCM55/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM55/ARMCM55_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -32,14 +33,19 @@ project(${CONTEXT} LANGUAGES CXX C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_CXX "-xc++" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
@@ -35,8 +35,8 @@ project(${CONTEXT} LANGUAGES CXX C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_CXX "-xc++" "--dlib_config DLib_Config_Full.h")
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_CXX "--c++" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C})

--- a/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
@@ -35,8 +35,8 @@ project(${CONTEXT} LANGUAGES CXX C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_CXX "--c++" "--dlib_config DLib_Config_Full.h")
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_CXX "--c++" "--dlib_config" "DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C})

--- a/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
+++ b/test/data/solutions/build-cpp/ref/project.IAR+ARMCM55/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM55/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM55/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM55/regions_ARMCM55.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -33,14 +34,19 @@ project(${CONTEXT} LANGUAGES CXX C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_CXX "-xc++" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_CXX} ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/executes/ref/project.Release+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/executes/ref/project.Release+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/Release")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES ASM C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES ASM C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES ASM C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/include-define/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +31,19 @@ project(${CONTEXT} LANGUAGES C CXX)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+set(CPP_OPTIONS_CXX "-xc++" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +32,19 @@ project(${CONTEXT} LANGUAGES C CXX)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+set(CPP_OPTIONS_CXX "-xc++" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +31,19 @@ project(${CONTEXT} LANGUAGES C CXX)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+set(CPP_OPTIONS_CXX "-xc++" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -33,8 +33,8 @@ project(${CONTEXT} LANGUAGES C CXX)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
-set(CPP_OPTIONS_CXX "-xc++" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_CXX "--c++" "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX})

--- a/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -33,8 +33,8 @@ project(${CONTEXT} LANGUAGES C CXX)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
-set(CPP_OPTIONS_CXX "--c++" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
+set(CPP_OPTIONS_CXX "--c++" "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX})

--- a/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/language-scope/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,8 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
+set(COMPILE_MACROS_CXX ${OUT_DIR}/compile_macros_cxx.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -31,14 +32,19 @@ project(${CONTEXT} LANGUAGES C CXX)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_CXX "-xc++" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C} ${COMPILE_MACROS_CXX}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
+  COMMAND ${CPP} ${CPP_OPTIONS_CXX} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_CXX}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})

--- a/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/library-rtos/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/link-lib/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/link-lib/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/link-lib/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/link-lib/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_MAP_FILE "project.map")
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ac6_linker_script.sct.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
@@ -35,14 +35,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_MAP_FILE "project.map")
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
@@ -35,14 +35,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_MAP_FILE "project.map")
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/gcc_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
@@ -35,14 +35,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_MAP_FILE "project.map")
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
@@ -35,14 +35,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -36,7 +36,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/linker-pre-processing/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -36,7 +36,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/pre-include-oot/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/../pre-include-oot/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/pre-include-oot/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/../pre-include-oot/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/pre-include-oot/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/../pre-include-oot/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/pre-include-oot/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/pre-include-oot/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/pre-include-oot/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include-oot/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/../pre-include-oot/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.AC6+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/AC6")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-Wno-macro-redefined" "-Wno-pragma-pack" "-Wno-parentheses-equality" "-Wno-license-management")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.CLANG+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/CLANG")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/clang_linker_script.ld.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/clang_linker_script.ld")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.GCC+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/GCC")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/ARMCM0_gcc.ld")
 set(LD_SCRIPT_PP ${LD_SCRIPT})
 
@@ -30,14 +30,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "-std=gnu11" "-masm-syntax-unified" "-fomit-frame-pointer" "-ffunction-sections" "-fdata-sections")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 

--- a/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config" "DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -32,7 +32,7 @@ project(${CONTEXT} LANGUAGES C)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Preprocessor options
-set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+set(CPP_OPTIONS_C "--dlib_config DLib_Config_Full.h")
 
 # Compilation database
 add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})

--- a/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
+++ b/test/data/solutions/pre-include/ref/project.IAR+ARMCM0/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OUT_DIR "${SOLUTION_ROOT}/out/project/ARMCM0/IAR")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COMPILE_COMMANDS ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 set(COMPILE_COMMANDS ${OUT_DIR}/compile_commands.json)
-set(COMPILE_MACROS ${OUT_DIR}/compile_macros.h)
+set(COMPILE_MACROS_C ${OUT_DIR}/compile_macros_c.h)
 set(LD_SCRIPT "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/iar_linker_script.icf.src")
 set(LD_REGIONS "${SOLUTION_ROOT}/project/RTE/Device/ARMCM0/regions_ARMCM0.h")
 set(LD_SCRIPT_PP "${CMAKE_CURRENT_BINARY_DIR}/iar_linker_script.icf")
@@ -31,14 +31,17 @@ project(${CONTEXT} LANGUAGES C)
 # Enable color diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
+# Preprocessor options
+set(CPP_OPTIONS_C "-xc" "--dlib_config DLib_Config_Full.h")
+
 # Compilation database
-add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS})
+add_custom_target(database DEPENDS ${COMPILE_COMMANDS} ${COMPILE_MACROS_C})
 add_custom_command(OUTPUT ${COMPILE_COMMANDS}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_COMPILE_COMMANDS}" "${COMPILE_COMMANDS}"
   DEPENDS "${CMAKE_COMPILE_COMMANDS}"
 )
-add_custom_command(OUTPUT ${COMPILE_MACROS}
-  COMMAND ${CPP} ${CPP_DUMP_MACROS}
+add_custom_command(OUTPUT ${COMPILE_MACROS_C}
+  COMMAND ${CPP} ${CPP_OPTIONS_C} ${CPP_DUMP_MACROS} "${COMPILE_MACROS_C}"
 )
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
 


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/625
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/335

Depends on https://github.com/Open-CMSIS-Pack/devtools/pull/2530

## Changes
- Ensures compile macro dumps use the appropriate C or C++ preprocessing mode and compiler options.
- Pass `-xc` or `-xc++`, or `--c++` in case of IAR, plus language-specific and common compiler options to macro dump commands.
- Update unit coverage and generated CMake reference fixtures across supported toolchains.
- Generating separate `compile_macros_c.h` and `compile_macros_cxx.h` files for enabled C and C++ languages has several advantages over a single-file approach:
  - Each file is a direct dump from the compiler preprocessor for one language mode.
  - No merging, comparison, filtering, or semantic transformation is required.
  - C and C++ differences are preserved exactly as reported by the compiler.
  - The consumer selects the file through the translation unit’s language, not through logic inside the generated file.
  - It avoids relying on any macro/define before the generated macro environment has been established.
  
## Risk / limitations
- The previous shared `compile_macros.h` output is replaced by language-specific files, which may affect consumers relying on that filename.
- Macro generation remains limited to C and C++.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).